### PR TITLE
Make holaplex optional

### DIFF
--- a/src/modules/bulk-minter/components/RoyaltiesCreators.tsx
+++ b/src/modules/bulk-minter/components/RoyaltiesCreators.tsx
@@ -375,10 +375,12 @@ export default function RoyaltiesCreators({
   const nftList = form.getFieldsValue(files.map((_, i) => `nft-${i}`)) as FormValues;
   const previousNFT: NFTFormValue | undefined = nftList[`nft-${index - 1}`];
 
-  const royaltyPercentageWithEnforcedRoyalties = 100 - HOLAPLEX_CREATOR_OBJECT.share; // 2% royalties for holaplex makes this 98
-  const defaultRoyaltyCreator = enforcedRoyalties
-  ? { address: userKey ?? '', share:  royaltyPercentageWithEnforcedRoyalties } 
-  : { address: userKey ?? '', share: 100 } 
+
+  let royaltyPercentageTotal = 100;
+  if (enforcedRoyalties) {
+    royaltyPercentageTotal -= HOLAPLEX_CREATOR_OBJECT.share;
+  }
+  const defaultRoyaltyCreator = { address: userKey ?? '', share:  royaltyPercentageTotal } 
    
   
 
@@ -426,7 +428,7 @@ export default function RoyaltiesCreators({
 
 
     setShowErrors(false);
-    if (total !== royaltyPercentageWithEnforcedRoyalties || creators.filter((creator) => creator.share === 0).length > 0) {
+    if (total !== royaltyPercentageTotal || creators.filter((creator) => creator.share === 0).length > 0) {
       setShowErrors(true);
     }
 
@@ -439,7 +441,7 @@ export default function RoyaltiesCreators({
 
     const zeroedRoyalties = creators.filter((creator) => creator.share === 0);
 
-    if (totalRoyaltyShares === 0 || totalRoyaltyShares > royaltyPercentageWithEnforcedRoyalties || zeroedRoyalties.length > 0) {
+    if (totalRoyaltyShares === 0 || totalRoyaltyShares > royaltyPercentageTotal || zeroedRoyalties.length > 0) {
       setShowErrors(true);
       return;
     }
@@ -510,7 +512,7 @@ export default function RoyaltiesCreators({
         if (creators.length >= MAX_CREATOR_LIMIT) {
           throw new Error('Max level of creators reached');
         }
-        const newShareSplit = royaltyPercentageWithEnforcedRoyalties / (creators.length + 1);
+        const newShareSplit = royaltyPercentageTotal / (creators.length + 1);
 
         setCreators([
           ...creators.map((c) => ({ ...c, share: newShareSplit })),
@@ -526,7 +528,7 @@ export default function RoyaltiesCreators({
   };
 
   const removeCreator = (creatorAddress: string) => {
-    const newShareSplit = 98 / (creators.length - 1);
+    const newShareSplit = royaltyPercentageTotal / (creators.length - 1);
 
     setCreators([
       ...creators
@@ -589,6 +591,7 @@ export default function RoyaltiesCreators({
             </Row>
           )}
           <Row>
+            {enforcedRoyalties && 
             <CreatorsRow
               creatorAddress={HOLAPLEX_CREATOR_OBJECT.address}
               share={HOLAPLEX_CREATOR_OBJECT.share}
@@ -596,6 +599,7 @@ export default function RoyaltiesCreators({
               updateCreator={updateCreator}
               removeCreator={removeCreator}
             />
+            }
             {creators.map((creator) => (
               <CreatorsRow
                 creatorAddress={creator.address}

--- a/src/modules/bulk-minter/components/RoyaltiesCreators.tsx
+++ b/src/modules/bulk-minter/components/RoyaltiesCreators.tsx
@@ -428,7 +428,7 @@ export default function RoyaltiesCreators({
 
 
     setShowErrors(false);
-    if (total !== royaltyPercentageTotal || creators.filter((creator) => creator.share === 0).length > 0) {
+    if (total !== royaltyPercentageTotal) {
       setShowErrors(true);
     }
 
@@ -439,9 +439,8 @@ export default function RoyaltiesCreators({
   const applyToAll = () => {
     if (showErrors) return;
 
-    const zeroedRoyalties = creators.filter((creator) => creator.share === 0);
 
-    if (totalRoyaltyShares === 0 || totalRoyaltyShares > royaltyPercentageTotal || zeroedRoyalties.length > 0) {
+    if (totalRoyaltyShares > royaltyPercentageTotal) {
       setShowErrors(true);
       return;
     }

--- a/src/modules/bulk-minter/index.tsx
+++ b/src/modules/bulk-minter/index.tsx
@@ -194,6 +194,7 @@ interface Props {
   connection: Connection;
   savedEndpoint?: string;
   goToOwnedRoute?: () => void;
+  enforcedRoyalties?: boolean;
 }
 
 function BulkMinter({
@@ -205,6 +206,7 @@ function BulkMinter({
   connection,
   savedEndpoint,
   goToOwnedRoute,
+  enforcedRoyalties = true,
 }: Props) {
   const [state, dispatch] = useReducer(reducer, initialState());
   const [form] = useForm();
@@ -309,17 +311,19 @@ function BulkMinter({
 
   const uploadMetaData = async (nftValue: NFTValue) => {
     const creators = nftValue.properties.creators as Creator[];
-    const creatorArrayWithHolaplexLast = [...creators, HOLAPLEX_CREATOR_OBJECT];
+    if (enforcedRoyalties) {
+      creators.push(HOLAPLEX_CREATOR_OBJECT)
+    }
 
-    const nftWithHolaplexAsLastCreator: NFTValue = {
+    const nftsWithCreators: NFTValue = {
       ...nftValue,
       properties: {
         ...nftValue.properties,
-        creators: creatorArrayWithHolaplexLast,
+        creators,
       },
     };
 
-    const metaData = new File([JSON.stringify(nftWithHolaplexAsLastCreator)], 'metadata');
+    const metaData = new File([JSON.stringify(nftsWithCreators)], 'metadata');
     const metaDataFileForm = new FormData();
     metaDataFileForm.append(`file[${metaData.name}]`, metaData, metaData.name);
 
@@ -418,6 +422,7 @@ function BulkMinter({
             index={0}
             onClose={onClose}
             track={track}
+            enforcedRoyalties={enforcedRoyalties}
           />
           {doEachRoyaltyInd &&
             files
@@ -436,6 +441,7 @@ function BulkMinter({
                   doEachRoyaltyInd={doEachRoyaltyInd}
                   onClose={onClose}
                   track={track}
+                  enforcedRoyalties={enforcedRoyalties}
                 />
               ))}
           <Summary


### PR DESCRIPTION
**Overview:** For some users, requiring Holaplex as a co-creator should be optional. This PR takes some steps to allow the co-creator to be configurable and optional.  It is mergeable as is but could use more work to make it feature complete.



*What's left to make this feature complete?*

- [ ] Allow required creator share to be configurable via an arg to  bulk minter
- [ ] Allow user to pass in required co-creator as an arg to bulkMinter